### PR TITLE
Add story status checkboxes to planning docs

### DIFF
--- a/docs/plan/EPIC-1_Stories.md
+++ b/docs/plan/EPIC-1_Stories.md
@@ -5,6 +5,7 @@ This document breaks down EPIC 1 into individual user stories, following the INV
 ---
 
 ### Story 1: Infinite Canvas View
+- [x] Completed
 
 - **As a** user,
 - **I want** an endless canvas workspace,
@@ -19,6 +20,7 @@ This document breaks down EPIC 1 into individual user stories, following the INV
 ---
 
 ### Story 2: Visual Grid System
+- [x] Completed
 
 - **As a** user,
 - **I want** to see a non-intrusive dotted grid on the canvas background,
@@ -33,6 +35,7 @@ This document breaks down EPIC 1 into individual user stories, following the INV
 ---
 
 ### Story 3: Canvas Panning
+- [x] Completed
 
 - **As a** user,
 - **I want** to pan the canvas in any direction (horizontally and vertically),
@@ -48,6 +51,7 @@ This document breaks down EPIC 1 into individual user stories, following the INV
 ---
 
 ### Story 4: Canvas Zooming
+- [x] Completed
 
 - **As a** user,
 - **I want** to zoom in and out on the canvas,
@@ -62,6 +66,7 @@ This document breaks down EPIC 1 into individual user stories, following the INV
 ---
 
 ### Story 5: Snap-to-Grid Alignment
+- [x] Completed
 
 - **As a** user,
 - **I want** objects to automatically snap to the nearest grid point when I move them,
@@ -76,6 +81,7 @@ This document breaks down EPIC 1 into individual user stories, following the INV
 ---
 
 ### Story 6: Responsive Canvas Layout
+- [x] Completed
 
 - **As a** user,
 - **I want** the canvas view to adapt to the size of my browser window,

--- a/docs/plan/EPIC-2_Stories.md
+++ b/docs/plan/EPIC-2_Stories.md
@@ -5,6 +5,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 1: Create Task Card
+- [x] Completed
 
 - **As a** user,
 - **I want** to create a new Task card on the canvas,
@@ -21,6 +22,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 2: Edit Task Card
+- [x] Completed
 
 - **As a** user,
 - **I want** to edit a Task card’s fields,
@@ -37,6 +39,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 3: Delete Task Card
+- [x] Completed
 
 - **As a** user,
 - **I want** to delete a Task card,
@@ -52,6 +55,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 4: Create State Card
+- [x] Completed
 
 - **As a** user,
 - **I want** to create a new State card on the canvas,
@@ -67,6 +71,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 5: Edit State Card
+- [x] Completed
 
 - **As a** user,
 - **I want** to edit a State card’s fields,
@@ -82,6 +87,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 6: Delete State Card
+- [x] Completed
 
 - **As a** user,
 - **I want** to delete a State card,
@@ -96,6 +102,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 7: Drag and Drop Cards
+- [x] Completed
 
 - **As a** user,
 - **I want** to drag and drop Task and State cards anywhere on the canvas,
@@ -111,6 +118,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 8: Card Snap-to-Grid
+- [x] Completed
 
 - **As a** user,
 - **I want** cards to snap to the grid when moved,
@@ -125,6 +133,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 9: Fork / Duplicate Card
+- [x] Completed
 
 - **As a** user,
 - **I want** to duplicate an existing Task or State card,
@@ -140,6 +149,7 @@ This document breaks down EPIC 2 into individual user stories, following the INV
 ---
 
 ### Story 10: Card Field Validation & Display
+- [x] Completed
 
 - **As a** user,
 - **I want** clear validation and consistent display of card fields,

--- a/docs/plan/EPIC-3_Stories.md
+++ b/docs/plan/EPIC-3_Stories.md
@@ -5,6 +5,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 1: Create Link (Task ➜ State)
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to create a directed visual link from a Task card to a State card,
@@ -20,6 +21,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 2: Fork New State From Existing State
+- [x] Completed
 
 - **As a** user,
 - **I want** to fork a new State from an existing State,
@@ -35,6 +37,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 3: Auto-Update Links When Cards Move
+- [x] Completed
 
 - **As a** user,
 - **I want** links to follow cards as I move them,
@@ -49,6 +52,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 4: Select and Inspect Links
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to select a link and see clear feedback,
@@ -63,6 +67,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 5: Delete Link
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to delete a link,
@@ -78,6 +83,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 6: Reassign Link Endpoints
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to reassign a link’s start or end to a different card,
@@ -93,6 +99,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 7: Visualize Relationship Hierarchy on Selection
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** relationship-focused highlighting,
@@ -107,6 +114,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 8: Link Validation Rules
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** clear rules preventing invalid connections,
@@ -122,6 +130,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 9: Link Routing, Layering, and Clarity
+- [x] Completed
 
 - **As a** user,
 - **I want** links to be readable and not obstruct content,
@@ -136,6 +145,7 @@ This document breaks down EPIC 3 into individual user stories, following the INV
 ---
 
 ### Story 10: Multiple Links and Fan-Out Management
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** multiple links from a Task to remain distinguishable,

--- a/docs/plan/EPIC-4_Stories.md
+++ b/docs/plan/EPIC-4_Stories.md
@@ -5,6 +5,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 1: Fixed Top Taskbar
+- [x] Completed
 
 - **As a** user,
 - **I want** a fixed taskbar at the top of the window,
@@ -19,6 +20,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 2: Create Task Button
+- [x] Completed
 
 - **As a** user,
 - **I want** a "Create Task" button in the taskbar,
@@ -33,6 +35,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 3: Configuration Menu
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** a Configuration menu accessible from the taskbar,
@@ -47,6 +50,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 4: Global UI Style Guidelines
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** a clean, minimal, and modern UI,
@@ -61,6 +65,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 5: Keyboard and Focus Accessibility
+- [ ] Not implemented yet
 
 - **As a** keyboard user,
 - **I want** to navigate and operate the taskbar and menus without a mouse,
@@ -75,6 +80,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 6: Modal or Inline Editors for Cards
+- [x] Completed
 
 - **As a** user,
 - **I want** to edit cards via a consistent editor experience (modal or inline),
@@ -89,6 +95,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 7: Non-Blocking UI Overlays
+- [x] Completed
 
 - **As a** user,
 - **I want** overlays (menus, modals) to behave predictably with the canvas,
@@ -103,6 +110,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 8: Theming Support (Light/Dark)
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to switch between light and dark themes,
@@ -117,6 +125,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 9: Layout Responsiveness & Safe Areas
+- [x] Completed
 
 - **As a** user,
 - **I want** the application shell to adapt to different screen sizes and safe areas,
@@ -131,6 +140,7 @@ This document breaks down EPIC 4 into individual user stories, following the INV
 ---
 
 ### Story 10: Performance & Visual Fidelity of Shell
+- [x] Completed
 
 - **As a** user,
 - **I want** the shell to render smoothly without jank,

--- a/docs/plan/EPIC-5_Stories.md
+++ b/docs/plan/EPIC-5_Stories.md
@@ -5,6 +5,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 1: Undo/Redo Framework
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** undo and redo for major actions,
@@ -20,6 +21,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 2: Search Cards by Text
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to search cards by title or description,
@@ -34,6 +36,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 3: Filter Cards by Properties
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to filter cards by priority, date range, or type (Task/State),
@@ -48,6 +51,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 4: Highlight Related Cards on Selection
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** related cards and links to be highlighted when I select an item,
@@ -62,6 +66,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 5: Smooth Interaction Performance
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** pan, zoom, drag, and selection interactions to remain smooth,
@@ -76,6 +81,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 6: Persistent UI Preferences (Session)
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** search/filter criteria and visibility preferences to persist for the session,
@@ -89,6 +95,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 7: Accessible Search & Filter
+- [ ] Not implemented yet
 
 - **As a** keyboard user,
 - **I want** to operate search and filters via keyboard,
@@ -103,6 +110,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 8: Keyboard Shortcuts for Discovery
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** keyboard shortcuts to quickly access search and filters,
@@ -117,6 +125,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 9: Navigate Search Results
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to jump between search matches,
@@ -131,6 +140,7 @@ This document breaks down EPIC 5 into individual user stories, following the INV
 ---
 
 ### Story 10: Interaction Conflict Handling
+- [x] Completed
 
 - **As a** user,
 - **I want** interactions to avoid conflicting gestures,

--- a/docs/plan/EPIC-6_Stories.md
+++ b/docs/plan/EPIC-6_Stories.md
@@ -5,6 +5,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 1: User Registration (Email/Password)
+- [ ] Not implemented yet
 
 - **As a** visitor,
 - **I want** to create an account with email and password,
@@ -19,6 +20,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 2: User Login & Logout
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to log in and log out,
@@ -33,6 +35,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 3: Secure Password Storage
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** passwords stored securely,
@@ -47,6 +50,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 4: Authenticated API Endpoints
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** my data requests to be protected by authentication,
@@ -61,6 +65,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 5: Associate Data to User
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** my tasks, states, and canvases associated with my account,
@@ -75,6 +80,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 6: Session Persistence (Client)
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to stay signed in across page reloads,
@@ -88,6 +94,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 7: Profile Basics
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** a minimal profile view,
@@ -101,6 +108,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 8: Change Password
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to change my password securely,
@@ -115,6 +123,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 9: Delete or Deactivate Account
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** to delete or deactivate my account,
@@ -129,6 +138,7 @@ This document breaks down EPIC 6 into individual user stories, following the INV
 ---
 
 ### Story 10: User Management API (CRUD)
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** API endpoints for user profile update and deletion,

--- a/docs/plan/EPIC-7_Stories.md
+++ b/docs/plan/EPIC-7_Stories.md
@@ -5,6 +5,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 1: Backend API Skeleton (Node.js)
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** a minimal backend API scaffold,
@@ -19,6 +20,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 2: Persist Cards and Positions
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** my tasks, states, and their positions saved,
@@ -33,6 +35,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 3: Persist Links
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** links between cards saved and restored,
@@ -46,6 +49,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 4: Load Canvas on App Start
+- [ ] Not implemented yet
 
 - **As a** user,
 - **I want** the canvas to load my data on app start,
@@ -59,6 +63,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 5: CRUD Endpoints for Tasks & States
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** full CRUD endpoints for tasks and states,
@@ -73,6 +78,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 6: Error Handling & Logging
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** consistent error handling and logs,
@@ -87,6 +93,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 7: Environment Configuration
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** environment-driven config,
@@ -100,6 +107,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 8: Data Model & Migrations (Basic)
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** a schema and migrations for core entities,
@@ -113,6 +121,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 9: Ownership & Auth Integration Points
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** endpoints ready to respect user ownership,
@@ -126,6 +135,7 @@ This document breaks down EPIC 7 into individual user stories, following the INV
 ---
 
 ### Story 10: Basic Rate Limiting & CORS
+- [ ] Not implemented yet
 
 - **As a** developer,
 - **I want** minimal protections and cross-origin access controls,


### PR DESCRIPTION
## Summary
- add checkbox status entries to every story under `docs/plan`
- update each story's status to reflect the current implementation state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f5b5310a28832db2a8836faee61d1b